### PR TITLE
Numark Mixtrack (Pro) 3 FX mapping enhancements (V1.7)

### DIFF
--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -148,6 +148,8 @@ var intervalsPerRev = 1200,
  *            - removed trailing empty lines at end of script
  *            - line 1749, change .75 to 0.75 in var gammaOutputRange 
  *            - added spacing in numerous place for easier reading
+ *2016-09-14 (1.3 ) - Stefan Mikolajczyk - https://github.com/mixxxdj/mixxx/pull/1012
+ *            - changed PADLoopButton behaviour to fit native serato behaviour (2, 4, 8, 16 instead of 1/8, 1/4, 1/2, 1)
  *
  * To do - (maybe..)
  * ----------------
@@ -1816,9 +1818,9 @@ NumarkMixtrack3.PADLoopButton = function(channel, control, value, status, group)
     var trueFalse;
     
     if (deck.shiftKey) {
-        loopsize = Math.pow(2, padindex);
-    } else {
         loopsize = Math.pow(2, padindex - 4);
+    } else {
+        loopsize = Math.pow(2, padindex);
     }
     
     var loopCommand1; //verify if loop is active

--- a/res/controllers/Numark-Mixtrack-3.midi.xml
+++ b/res/controllers/Numark-Mixtrack-3.midi.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<!-- Numark Mixtrack (Pro) 3 MIDI preset v1.3 -->
+<!-- Numark Mixtrack (Pro) 3 MIDI preset v1.7 -->
 <MixxxControllerPreset mixxxVersion="1.12.0+" schemaVersion="1">
     <info>
 	<name>Numark Mixtrack (Pro) 3</name>
@@ -872,7 +872,27 @@
                 <options>
                     <script-binding/>
                 </options>
+            </control>		
+   			<control>
+                <group>[Channel1]</group>
+                <key>NumarkMixtrack3.InstantFXOff</key>
+				<description>Channel 1 strip Instant FX Off</description>
+                <status>0x91</status>
+                <midino>0x1F</midino>
+                <options>
+                    <script-binding/>
+                </options>
             </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>NumarkMixtrack3.InstantFXOff</key>
+				<description>Channel 2 strip Instant FX Off</description>
+                <status>0x92</status>
+                <midino>0x1F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>			
             <control>
                 <group>[Channel1]</group>
                 <key>NumarkMixtrack3.StripTouchSearch</key>

--- a/res/skins/Deere/deck_overview_row.xml
+++ b/res/skins/Deere/deck_overview_row.xml
@@ -27,7 +27,7 @@
         <SignalColor><Variable name="DeckSignalColor"/></SignalColor>
         <PlayPosColor>#00FF00</PlayPosColor>
         <DefaultMark>
-          <Align>bottom</Align>
+          <Align>bottom|right</Align>
           <Color>#00FF00</Color>
           <TextColor>#FFFFFF</TextColor>
           <Text> %1 </Text>
@@ -41,7 +41,7 @@
         </MarkRange>
         <Mark>
           <Control>cue_point</Control>
-          <Align>top</Align>
+          <Align>top|right</Align>
           <Color>#FF001C</Color>
           <TextColor>#FFFFFF</TextColor>
           <Text>C</Text>

--- a/res/skins/LateNight/deck_row_5.xml
+++ b/res/skins/LateNight/deck_row_5.xml
@@ -22,7 +22,7 @@
 				<PlayPosColor>#00FF00</PlayPosColor>
 				<EndOfTrackColor>#EA0000</EndOfTrackColor>
 				<DefaultMark>
-					<Align>bottom</Align>
+					<Align>bottom|right</Align>
 					<Color>#00FF00</Color>
 					<TextColor>#FFFFFF</TextColor>
 					<Text> %1 </Text>
@@ -37,7 +37,7 @@
 				<Mark>
 					<Control>cue_point</Control>
 					<Text>C</Text>
-					<Align>top</Align>
+					<Align>top|right</Align>
 					<Color>#FF001C</Color>
 					<TextColor>#FFFFFF</TextColor>
 				</Mark>

--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -223,7 +223,7 @@
 							<PlayPosColor>#00FF00</PlayPosColor>
 							<EndOfTrackColor>#EA0000</EndOfTrackColor>
 							<DefaultMark>
-								<Align>bottom</Align>
+								<Align>bottom|right</Align>
 								<Color>#FD0564</Color>
 								<TextColor>#FFFFFF</TextColor>
 								<Text> %1 </Text>
@@ -238,7 +238,7 @@
 							<Mark>
 								<Control>cue_point</Control>
 								<Text>C</Text>
-								<Align>top</Align>
+								<Align>top|right</Align>
 								<Color>#FF001C</Color>
 								<TextColor>#FFFFFF</TextColor>
 							</Mark>

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -213,6 +213,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                    tr("Cue button (CDJ mode)"), cueMenu);
     addDeckControl("play_stutter", tr("Stutter Cue"),
                    tr("Stutter cue"), cueMenu);
+    addDeckControl("cue_play", tr("Cue (Cue Play)"),
+                       tr("Go to cue point and play after release"), cueMenu);
 
     // Hotcues
     QMenu* hotcueMenu = addSubmenu(tr("Hotcues"));

--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -111,7 +111,8 @@ DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
             << "Timothy Rae"
             << "Roland Schwarz"
             << "Jan Ypma"
-            << "Leigh Scott";
+            << "Leigh Scott"
+            << "William Lemus";
 
     QStringList specialThanks;
     specialThanks

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -115,6 +115,7 @@ class CueControl : public EngineControl {
     void cuePreview(double v);
     void cueCDJ(double v);
     void cueDenon(double v);
+    void cuePlay(double v);
     void cueDefault(double v);
     void pause(double v);
     void playStutter(double v);
@@ -149,6 +150,7 @@ class CueControl : public EngineControl {
     ControlIndicator* m_pPlayIndicator;
     ControlPushButton* m_pCueGoto;
     ControlPushButton* m_pCueGotoAndPlay;
+    ControlPushButton* m_pCuePlay;
     ControlPushButton* m_pCueGotoAndStop;
     ControlPushButton* m_pCuePreview;
     ControlProxy* m_pVinylControlEnabled;

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -5,9 +5,11 @@
 
 #include <QScopedPointer>
 
+#include "control/controlproxy.h"
 #include "library/trackcollection.h"
 #include "library/searchqueryparser.h"
 #include "library/queryutil.h"
+#include "track/keyutils.h"
 #include "util/performancetimer.h"
 
 namespace {
@@ -41,6 +43,7 @@ BaseTrackCache::BaseTrackCache(TrackCollection* pTrackCollection,
                     << "title"
                     << "genre";
 
+    m_pKeyNotationCP = new ControlProxy("[Library]", "key_notation", this);
     // Convert all the search column names to their field indexes because we use
     // them a bunch.
     m_searchColumnIndices.resize(m_searchColumns.size());
@@ -619,6 +622,19 @@ int BaseTrackCache::compareColumnValues(int sortColumn, Qt::SortOrder sortOrder,
             result = 1;
         else
             result = -1;
+    } else if (sortColumn == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY)) {
+        double notation = m_pKeyNotationCP->get();
+        int key1 = KeyUtils::keyToCircleOfFithsOrder(
+                       KeyUtils::guessKeyFromText(val1.toString()), notation);
+        int key2 = KeyUtils::keyToCircleOfFithsOrder(
+                       KeyUtils::guessKeyFromText(val2.toString()), notation);
+        if (key1 > key2) {
+            result = 1;
+        } else if (key1 < key2) {
+            result = -1;
+        } else if (key1 == key2) {
+            result = 0;
+        }
     } else {
         result = val1.toString().localeAwareCompare(val2.toString());
     }

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -13,6 +13,7 @@
 #include <QSqlDatabase>
 #include <QVector>
 
+#include "control/controlproxy.h"
 #include "library/dao/trackdao.h"
 #include "library/columncache.h"
 #include "track/track.h"
@@ -133,6 +134,7 @@ class BaseTrackCache : public QObject {
     TrackDAO& m_trackDAO;
     QSqlDatabase m_database;
     SearchQueryParser* m_pQueryParser;
+    ControlProxy* m_pKeyNotationCP;
 
     DISALLOW_COPY_AND_ASSIGN(BaseTrackCache);
 };

--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -3,6 +3,20 @@
 #include "library/dao/trackdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/cratedao.h"
+#include "track/keyutils.h"
+#include "track/key_preferences.h"
+#include "control/controlproxy.h"
+
+ ColumnCache::ColumnCache(const QStringList& columns) {
+    m_pKeyNotationCP = new ControlProxy("[Library]", "key_notation", this);
+    m_pKeyNotationCP->connectValueChanged(SLOT(slotSetKeySortOrder(double)));
+
+    // ColumnCache is initialized before the preferences, so slotSetKeySortOrder is called
+    // for again if DlgPrefKey sets the [Library]. key_notation CO to a value other than
+    // KeyUtils::CUSTOM as Mixxx is starting.
+
+    setColumns(columns);
+}
 
 void ColumnCache::setColumns(const QStringList& columns) {
     m_columnsByIndex.clear();
@@ -71,6 +85,7 @@ void ColumnCache::setColumns(const QStringList& columns) {
 
     const QString sortInt("cast(%1 as integer)");
     const QString sortNoCase("lower(%1)");
+
     m_columnSortByIndex.clear();
     // Add the columns that requires a special sort
     m_columnSortByIndex.insert(m_columnIndexByEnum[COLUMN_LIBRARYTABLE_ARTIST], sortNoCase);
@@ -89,4 +104,25 @@ void ColumnCache::setColumns(const QStringList& columns) {
     m_columnSortByIndex.insert(m_columnIndexByEnum[COLUMN_PLAYLISTTRACKSTABLE_LOCATION], sortNoCase);
     m_columnSortByIndex.insert(m_columnIndexByEnum[COLUMN_PLAYLISTTRACKSTABLE_ARTIST], sortNoCase);
     m_columnSortByIndex.insert(m_columnIndexByEnum[COLUMN_PLAYLISTTRACKSTABLE_TITLE], sortNoCase);
+
+    slotSetKeySortOrder(m_pKeyNotationCP->get());
+}
+
+void ColumnCache::slotSetKeySortOrder(double notation) {
+    if (m_columnIndexByEnum[COLUMN_LIBRARYTABLE_KEY] < 0) return;
+
+    // A custom COLLATE function was tested, but using CASE ... WHEN was found to be faster
+    // see GitHub PR#649
+    // https://github.com/mixxxdj/mixxx/pull/649#discussion_r34863809
+    QString keySortSQL("CASE %1_id WHEN NULL THEN 0 ");
+    for (int i = 0; i <= 24; ++i) {
+        keySortSQL.append(QString("WHEN %1 THEN %2 ")
+            .arg(QString::number(i),
+                 QString::number(KeyUtils::keyToCircleOfFithsOrder(
+                                     static_cast<mixxx::track::io::key::ChromaticKey>(i),
+                                     notation))));
+    }
+    keySortSQL.append("END");
+
+    m_columnSortByIndex.insert(m_columnIndexByEnum[COLUMN_LIBRARYTABLE_KEY], keySortSQL);
 }

--- a/src/library/columncache.h
+++ b/src/library/columncache.h
@@ -1,12 +1,19 @@
 #ifndef COLUMNCACHE_H
 #define COLUMNCACHE_H
 
+#include <QObject>
 #include <QMap>
 #include <QStringList>
 
+#include "track/keyutils.h"
+#include "preferences/usersettings.h"
+
+class ControlProxy;
+
 // Caches the index of frequently used columns and provides a lookup-table of
 // column name to index.
-class ColumnCache {
+class ColumnCache : public QObject {
+  Q_OBJECT
   public:
 
     enum Column {
@@ -66,10 +73,7 @@ class ColumnCache {
         NUM_COLUMNS
     };
 
-    ColumnCache() { }
-    ColumnCache(const QStringList& columns) {
-        setColumns(columns);
-    }
+    explicit ColumnCache(const QStringList& columns = QStringList());
 
     void setColumns(const QStringList& columns);
 
@@ -106,6 +110,12 @@ class ColumnCache {
     QMap<QString, int> m_columnIndexByName;
     // A mapping from column enum to logical index.
     int m_columnIndexByEnum[NUM_COLUMNS];
+
+  private:
+    ControlProxy* m_pKeyNotationCP;
+
+  private slots:
+    void slotSetKeySortOrder(double);
 };
 
 #endif /* COLUMNCACHE_H */

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -53,6 +53,8 @@ Library::Library(QObject* parent, UserSettingsPointer pConfig,
         m_scanner(m_pTrackCollection, pConfig) {
     qRegisterMetaType<Library::RemovalType>("Library::RemovalType");
 
+    m_pKeyNotation.reset(new ControlObject(ConfigKey("[Library]", "key_notation")));
+
     connect(&m_scanner, SIGNAL(scanStarted()),
             this, SIGNAL(scanStarted()));
     connect(&m_scanner, SIGNAL(scanFinished()),

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -134,6 +134,7 @@ public:
     LibraryScanner m_scanner;
     QFont m_trackTableFont;
     int m_iTrackTableRowHeight;
+    QScopedPointer<ControlObject> m_pKeyNotation;
 };
 
 #endif /* LIBRARY_H */

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -242,6 +242,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     ComboBoxCueDefault->addItem(tr("Pioneer mode"), 1);
     ComboBoxCueDefault->addItem(tr("Denon mode"), 2);
     ComboBoxCueDefault->addItem(tr("Numark mode"), 3);
+    ComboBoxCueDefault->addItem(tr("CUP mode"), 5);
     const int cueDefaultIndex = cueDefaultIndexByData(cueDefaultValue);
     ComboBoxCueDefault->setCurrentIndex(cueDefaultIndex);
     slotSetCueDefault(cueDefaultIndex);

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -22,7 +22,7 @@
 
 #include "analyzer/vamp/vampanalyzer.h"
 #include "analyzer/vamp/vamppluginloader.h"
-#include "control/controlobject.h"
+#include "control/controlproxy.h"
 #include "track/key_preferences.h"
 #include "util/xml.h"
 
@@ -65,6 +65,8 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer _config)
     m_keyLineEdits.insert(mixxx::track::io::key::A_MINOR, a_minor_edit);
     m_keyLineEdits.insert(mixxx::track::io::key::B_FLAT_MINOR, b_flat_minor_edit);
     m_keyLineEdits.insert(mixxx::track::io::key::B_MINOR, b_minor_edit);
+
+    m_pKeyNotation = new ControlProxy(ConfigKey("[Library]", "key_notation"), this);
 
     populate();
     loadSettings();
@@ -325,6 +327,7 @@ void DlgPrefKey::setNotationCustom(bool active) {
          it != m_keyLineEdits.end(); ++it) {
         it.value()->setEnabled(true);
     }
+    m_pKeyNotation->set(KeyUtils::CUSTOM);
     slotUpdate();
 }
 
@@ -334,6 +337,7 @@ void DlgPrefKey::setNotation(KeyUtils::KeyNotation notation) {
         it.value()->setText(KeyUtils::keyToString(it.key(), notation));
         it.value()->setEnabled(false);
     }
+    m_pKeyNotation->set(notation);
     slotUpdate();
 }
 

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -5,6 +5,7 @@
 #include <QWidget>
 #include <QMap>
 
+#include "control/controlproxy.h"
 #include "preferences/dialog/ui_dlgprefkeydlg.h"
 #include "preferences/usersettings.h"
 #include "track/keyutils.h"
@@ -43,6 +44,7 @@ class DlgPrefKey : public DlgPreferencePage, Ui::DlgPrefKeyDlg {
     QList<QString> m_listName;
     QList<QString> m_listLibrary, m_listIdentifier;
     QString m_selectedAnalyzer;
+    ControlProxy* m_pKeyNotation;
     bool m_bAnalyzerEnabled;
     bool m_bFastAnalysisEnabled;
     bool m_bReanalyzeEnabled;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -159,7 +159,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     qDebug() << "RLimit Max " << RLimit::getMaxRtPrio();
 
     if (RLimit::isRtPrioAllowed()) {
-        limitsHint->hide();
+        limitsHint->setText(tr("Realtime scheduling is enabled."));
     }
 #else
     // the limits warning is a Linux only thing

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -282,7 +282,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QLabel" name="limitsHint">
         <property name="text">
          <string>Enable Real-Time scheduling (currently disabled), see the &lt;a href=&quot;http://mixxx.org/wiki/doku.php/adjusting_audio_latency&quot;&gt;Mixxx Wiki&lt;/a&gt;.</string>
@@ -295,7 +295,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QLabel" name="hardwareGuide">
         <property name="text">
          <string>The &lt;a href=&quot;http://mixxx.org/wiki/doku.php/hardware_compatibility&quot;&gt;Mixxx DJ Hardware Guide&lt;/a&gt; lists sound cards and controllers you may want to consider for using Mixxx.</string>
@@ -308,14 +308,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="Line" name="line">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="6" column="0">
         <widget class="QLabel" name="latencyLabel">
          <property name="text">
           <string>System Reported Latency</string>
@@ -325,14 +325,14 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="6" column="1">
         <widget class="QLabel" name="currentLatency">
          <property name="text">
           <string>20 ms</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="underflowLabel">
          <property name="text">
           <string>Buffer Underflow Count</string>
@@ -342,7 +342,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="7" column="1">
         <widget class="QLabel" name="bufferUnderflowCount">
          <property name="text">
           <string>0</string>

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -400,7 +400,7 @@ void Tooltips::addStandardTooltips() {
     add("cue_default_cue_gotoandstop")
             << tr("Cue")
             << QString("%1 %2: %3").arg(leftClick, whilePlaying, tr("Stops track at cue point."))
-            << QString("%1 %2: %3").arg(leftClick, whileStopped, tr("Set cue point (Pioneer/Mixxx mode) OR preview from it (Denon mode)."))
+            << QString("%1 %2: %3").arg(leftClick, whileStopped, tr("Set cue point (Pioneer/Mixxx mode), set cue point and play (CUP mode) OR preview from it (Denon mode)."))
             << tr("Hint: Change the default cue mode in Preferences -> Interface.")
             << quantizeSnap
             << QString("%1: %2").arg(rightClick, tr("Seeks the track to the cue-point and stops."));

--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -85,10 +85,14 @@ TEST_F(KeyUtilsTest, KeyNameNotation) {
     // Sharps
     EXPECT_EQ(mixxx::track::io::key::D_FLAT_MAJOR,
               KeyUtils::guessKeyFromText("C#"));
+    EXPECT_EQ(mixxx::track::io::key::D_FLAT_MAJOR,
+              KeyUtils::guessKeyFromText(QString::fromUtf8("C♯")));
 
     // Flats
     EXPECT_EQ(mixxx::track::io::key::D_FLAT_MAJOR,
               KeyUtils::guessKeyFromText("Db"));
+    EXPECT_EQ(mixxx::track::io::key::D_FLAT_MAJOR,
+              KeyUtils::guessKeyFromText(QString::fromUtf8("D♭")));
 
     // Mixed sharps and flats.
     EXPECT_EQ(mixxx::track::io::key::C_MINOR,

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -7,29 +7,55 @@
 #include "track/keyutils.h"
 #include "util/math.h"
 
+#define MUSIC_FLAT_UTF8  "\xe299ad"
+#define MUSIC_SHARP_UTF8 "\xe299af"
+
 using mixxx::track::io::key::ChromaticKey;
 using mixxx::track::io::key::ChromaticKey_IsValid;
 
 // OpenKey notation, the numbers 1-12 followed by d (dur, major) or m (moll, minor).
-static const char* s_openKeyPattern = "^\\s*(1[0-2]|[1-9])([dm])\\s*$";
+static const QString s_openKeyPattern("^\\s*(1[0-2]|[1-9])([dm])\\s*$");
 
 // Lancelot notation, the numbers 1-12 followed by a (minor) or b (major).
-static const char* s_lancelotKeyPattern = "^\\s*(1[0-2]|[1-9])([ab])\\s*$";
+static const QString s_lancelotKeyPattern("^\\s*(1[0-2]|[1-9])([ab])\\s*$");
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale spec (m = minor, min, maj)
 // anchor the pattern so we don't get accidental sub-string matches
 // (?:or)? allows unabbreviated major|minor without capturing
-static const char* s_keyPattern = "^\\s*([a-g])([#♯b♭]*)"
-    "(min(?:or)?|maj(?:or)?|m)?\\s*$";
+static const QString s_keyPattern = QString::fromUtf8(
+        "^\\s*([a-g])([#♯b♭]*)"
+        "(min(?:or)?|maj(?:or)?|m)?\\s*$");
 
 static const QString s_sharpSymbol = QString::fromUtf8("♯");
-static const QString s_flatSymbol = QString::fromUtf8("♭");
+//static const QString s_flatSymbol = QString::fromUtf8("♭");
 
-static const char *s_traditionalKeyNames[] = {
-    "INVALID",
-    "C", "D♭", "D", "E♭", "E", "F", "F♯/G♭", "G", "A♭", "A", "B♭", "B",
-    "Cm", "C♯m", "Dm", "D♯m/E♭m", "Em", "Fm", "F♯m", "Gm", "G♯m", "Am", "B♭m", "Bm"
+static const QString s_traditionalKeyNames[] = {
+    QString::fromUtf8("INVALID"),
+    QString::fromUtf8("C"),
+    QString::fromUtf8("D♭"),
+    QString::fromUtf8("D"),
+    QString::fromUtf8("E♭"),
+    QString::fromUtf8("E"),
+    QString::fromUtf8("F"),
+    QString::fromUtf8("F♯/G♭"),
+    QString::fromUtf8("G"),
+    QString::fromUtf8("A♭"),
+    QString::fromUtf8("A"),
+    QString::fromUtf8("B♭"),
+    QString::fromUtf8("B"),
+    QString::fromUtf8("Cm"),
+    QString::fromUtf8("C♯m"),
+    QString::fromUtf8("Dm"),
+    QString::fromUtf8("D♯m/E♭m"),
+    QString::fromUtf8("Em"),
+    QString::fromUtf8("Fm"),
+    QString::fromUtf8("F♯m"),
+    QString::fromUtf8("Gm"),
+    QString::fromUtf8("G♯m"),
+    QString::fromUtf8("Am"),
+    QString::fromUtf8("B♭m"),
+    QString::fromUtf8("Bm")
 };
 
 // Maps an OpenKey number to its major and minor key.
@@ -61,6 +87,86 @@ const ChromaticKey s_letterToMajorKey[] = {
     mixxx::track::io::key::E_MAJOR,
     mixxx::track::io::key::F_MAJOR,
     mixxx::track::io::key::G_MAJOR
+};
+
+static const QList<mixxx::track::io::key::ChromaticKey> s_sortKeysCircleOfFifths {
+    mixxx::track::io::key::INVALID,
+
+    mixxx::track::io::key::C_MAJOR,
+    mixxx::track::io::key::A_MINOR,
+
+    mixxx::track::io::key::G_MAJOR,
+    mixxx::track::io::key::E_MINOR,
+
+    mixxx::track::io::key::D_MAJOR,
+    mixxx::track::io::key::B_MINOR,
+
+    mixxx::track::io::key::A_MAJOR,
+    mixxx::track::io::key::F_SHARP_MINOR,
+
+    mixxx::track::io::key::E_MAJOR,
+    mixxx::track::io::key::C_SHARP_MINOR,
+
+    mixxx::track::io::key::B_MAJOR,
+    mixxx::track::io::key::G_SHARP_MINOR,
+
+    mixxx::track::io::key::F_SHARP_MAJOR,
+    mixxx::track::io::key::E_FLAT_MINOR,
+
+    mixxx::track::io::key::D_FLAT_MAJOR,
+    mixxx::track::io::key::B_FLAT_MINOR,
+
+    mixxx::track::io::key::A_FLAT_MAJOR,
+    mixxx::track::io::key::F_MINOR,
+
+    mixxx::track::io::key::E_FLAT_MAJOR,
+    mixxx::track::io::key::C_MINOR,
+
+    mixxx::track::io::key::B_FLAT_MAJOR,
+    mixxx::track::io::key::G_MINOR,
+
+    mixxx::track::io::key::F_MAJOR,
+    mixxx::track::io::key::D_MINOR
+};
+
+static const QList<mixxx::track::io::key::ChromaticKey> s_sortKeysCircleOfFifthsLancelot {
+    mixxx::track::io::key::INVALID,
+
+    mixxx::track::io::key::G_SHARP_MINOR,
+    mixxx::track::io::key::B_MAJOR,
+
+    mixxx::track::io::key::E_FLAT_MINOR,
+    mixxx::track::io::key::F_SHARP_MAJOR,
+
+    mixxx::track::io::key::B_FLAT_MINOR,
+    mixxx::track::io::key::D_FLAT_MAJOR,
+
+    mixxx::track::io::key::F_MINOR,
+    mixxx::track::io::key::A_FLAT_MAJOR,
+
+    mixxx::track::io::key::C_MINOR,
+    mixxx::track::io::key::E_FLAT_MAJOR,
+
+    mixxx::track::io::key::G_MINOR,
+    mixxx::track::io::key::B_FLAT_MAJOR,
+
+    mixxx::track::io::key::D_MINOR,
+    mixxx::track::io::key::F_MAJOR,
+
+    mixxx::track::io::key::A_MINOR,
+    mixxx::track::io::key::C_MAJOR,
+
+    mixxx::track::io::key::E_MINOR,
+    mixxx::track::io::key::G_MAJOR,
+
+    mixxx::track::io::key::B_MINOR,
+    mixxx::track::io::key::D_MAJOR,
+
+    mixxx::track::io::key::F_SHARP_MINOR,
+    mixxx::track::io::key::A_MAJOR,
+
+    mixxx::track::io::key::C_SHARP_MINOR,
+    mixxx::track::io::key::E_MAJOR,
 };
 
 QMutex KeyUtils::s_notationMutex;
@@ -95,7 +201,7 @@ QString KeyUtils::keyDebugName(ChromaticKey key) {
     if (!ChromaticKey_IsValid(key)) {
         key = mixxx::track::io::key::INVALID;
     }
-    return QString::fromUtf8(s_traditionalKeyNames[static_cast<int>(key)]);
+    return s_traditionalKeyNames[static_cast<int>(key)];
 }
 
 // static
@@ -122,7 +228,9 @@ QString KeyUtils::keyToString(ChromaticKey key,
         return "INVALID";
     }
 
-    if (notation == DEFAULT) {
+    if (notation == CUSTOM) {
+        // The default value for notation is KeyUtils::CUSTOM, so this executes when the function is
+        // called without a notation specified after KeyUtils::setNotation has set up s_notation.
         QMutexLocker locker(&s_notationMutex);
         QMap<ChromaticKey, QString>::const_iterator it = s_notation.find(key);
         if (it != s_notation.end()) {
@@ -137,7 +245,7 @@ QString KeyUtils::keyToString(ChromaticKey key,
         int number = openKeyNumberToLancelotNumber(keyToOpenKeyNumber(key));
         return QString::number(number) + (major ? "B" : "A");
     } else if (notation == TRADITIONAL) {
-        return QString::fromUtf8(s_traditionalKeyNames[static_cast<int>(key)]);
+        return s_traditionalKeyNames[static_cast<int>(key)];
     }
     return keyDebugName(key);
 }
@@ -452,4 +560,13 @@ QList<mixxx::track::io::key::ChromaticKey> KeyUtils::getCompatibleKeys(
     compatible << openKeyNumberToKey(
             openKeyNumber == 1 ? 12 : openKeyNumber - 1, major);
     return compatible;
+}
+
+int KeyUtils::keyToCircleOfFithsOrder(mixxx::track::io::key::ChromaticKey key,
+                                      double notationValue) {
+    if (notationValue != static_cast<double>(KeyUtils::LANCELOT)) {
+      return s_sortKeysCircleOfFifths.indexOf(key);
+    } else {
+      return s_sortKeysCircleOfFifthsLancelot.indexOf(key);
+    }
 }

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QList>
 
+#include "control/controlproxy.h"
 #include "proto/keys.pb.h"
 #include "track/keys.h"
 #include "util/math.h"
@@ -12,8 +13,7 @@
 class KeyUtils {
   public:
     enum KeyNotation {
-        // The default notation (set with setNotation).
-        DEFAULT = 0,
+        CUSTOM = 0,
         OPEN_KEY = 1,
         LANCELOT = 2,
         TRADITIONAL = 3,
@@ -41,11 +41,11 @@ class KeyUtils {
     }
 
     static QString keyToString(mixxx::track::io::key::ChromaticKey key,
-                               KeyNotation notation = DEFAULT);
+                               KeyNotation notation = CUSTOM);
 
     static QString getGlobalKeyText(
             const Keys& keys,
-            KeyNotation notation = DEFAULT);
+            KeyNotation notation = CUSTOM);
 
     static mixxx::track::io::key::ChromaticKey keyFromNumericValue(double value);
 
@@ -154,6 +154,9 @@ class KeyUtils {
                 return 0;
         }
     }
+
+    static int keyToCircleOfFithsOrder(mixxx::track::io::key::ChromaticKey key,
+                                       double notationValue);
 
   private:
     static QMutex s_notationMutex;

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -285,6 +285,10 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
+        if (m_orientation == Qt::Vertical) {
+            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+            glScalef(-1.0f, 1.0f, 1.0f);
+        }
         glOrtho(firstVisualIndex, lastVisualIndex, -1.0, 1.0, -10.0, 10.0);
 
         glMatrixMode(GL_MODELVIEW);

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -79,6 +79,10 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glLoadIdentity();
+    if (m_orientation == Qt::Vertical) {
+        glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+        glScalef(-1.0f, 1.0f, 1.0f);
+    }
 
     //t8 = timer.restart(); // 2,611 ns
 

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -75,6 +75,10 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
+        if (m_orientation == Qt::Vertical) {
+            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+            glScalef(-1.0f, 1.0f, 1.0f);
+        }
         glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
 
         glMatrixMode(GL_MODELVIEW);
@@ -136,7 +140,11 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
-        if (m_alignment == Qt::AlignBottom)
+        if (m_orientation == Qt::Vertical) {
+            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+            glScalef(-1.0f, 1.0f, 1.0f);
+        }
+        if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight)
             glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
         else
             glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -68,6 +68,10 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
+        if (m_orientation == Qt::Vertical) {
+            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+            glScalef(-1.0f, 1.0f, 1.0f);
+        }
         glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
 
         glMatrixMode(GL_MODELVIEW);
@@ -139,7 +143,11 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
-        if (m_alignment == Qt::AlignBottom) {
+        if (m_orientation == Qt::Vertical) {
+            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+            glScalef(-1.0f, 1.0f, 1.0f);
+        }
+        if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight) {
             glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
         } else {
             glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -73,6 +73,10 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
+        if (m_orientation == Qt::Vertical) {
+            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+            glScalef(-1.0f, 1.0f, 1.0f);
+        }
         glOrtho(firstVisualIndex, lastVisualIndex, -255.0, 255.0, -10.0, 10.0);
 
         glMatrixMode(GL_MODELVIEW);
@@ -119,7 +123,11 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
-        if (m_alignment == Qt::AlignBottom)
+        if (m_orientation == Qt::Vertical) {
+            glRotatef(90.0f, 0.0f, 0.0f, 1.0f);
+            glScalef(-1.0f, 1.0f, 1.0f);
+        }
+        if (m_alignment == Qt::AlignBottom || m_alignment == Qt::AlignRight)
             glOrtho(firstVisualIndex, lastVisualIndex, 0.0, 255.0, -10.0, 10.0);
         else
             glOrtho(firstVisualIndex, lastVisualIndex, 255.0, 0.0, -10.0, 10.0);

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -5,12 +5,12 @@
 
 #include "waveformmark.h"
 
-WaveformMark::WaveformMark()
-    : m_iHotCue(-1) {
-}
-
 WaveformMark::WaveformMark(int hotCue)
     : m_iHotCue(hotCue) {
+}
+
+void WaveformMark::reset(int hotCue) {
+    WaveformMark(hotCue).swap(*this);
 }
 
 void WaveformMark::setup(const QString& group, const QDomNode& node,

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -14,8 +14,26 @@ class WaveformSignalColors;
 
 class WaveformMark {
   public:
-    WaveformMark();
-    WaveformMark(int hotCue);
+    static const int kDefaultHotCue = -1;
+
+    explicit WaveformMark(int hotCue = kDefaultHotCue);
+
+    // Disable copying
+    WaveformMark(const WaveformMark&) = delete;
+    WaveformMark& operator=(const WaveformMark&) = delete;
+
+    // Enable swapping
+    void swap(WaveformMark& that) {
+        std::swap(m_pPointCos, that.m_pPointCos);
+        std::swap(m_properties, that.m_properties);
+        std::swap(m_iHotCue, that.m_iHotCue);
+        std::swap(m_image, that.m_image);
+    }
+    friend void swap(WaveformMark& lhs, WaveformMark& rhs) {
+        lhs.swap(rhs);
+    }
+
+    void reset(int hotCue = kDefaultHotCue);
 
     void setup(const QString& group, const QDomNode& node,
                const SkinContext& context,

--- a/src/waveform/renderers/waveformmarkproperties.cpp
+++ b/src/waveform/renderers/waveformmarkproperties.cpp
@@ -4,6 +4,43 @@
 
 #include "waveform/renderers/waveformmarkproperties.h"
 
+Qt::Alignment decodeAlignmentFlags(QString alignString, Qt::Alignment defaultFlags) {
+    QStringList stringFlags = alignString.toLower()
+            .split("|", QString::SkipEmptyParts);
+
+    Qt::Alignment hflags = 0L;
+    Qt::Alignment vflags = 0L;
+
+    for (auto stringFlag : stringFlags) {
+        if (stringFlag == "center") {
+            hflags |= Qt::AlignHCenter;
+            vflags |= Qt::AlignVCenter;
+        } else if (stringFlag == "left") {
+            hflags |= Qt::AlignLeft;
+        } else if (stringFlag == "hcenter") {
+            hflags |= Qt::AlignHCenter;
+        } else if (stringFlag == "right") {
+            hflags |= Qt::AlignRight;
+        } else if (stringFlag == "top") {
+            vflags |= Qt::AlignTop;
+        } else if (stringFlag == "vcenter") {
+            vflags |= Qt::AlignVCenter;
+        } else if (stringFlag == "bottom") {
+            vflags |= Qt::AlignBottom;
+        }
+    }
+
+    if (hflags != Qt::AlignLeft && hflags != Qt::AlignHCenter && hflags != Qt::AlignRight) {
+        hflags = defaultFlags & Qt::AlignHorizontal_Mask;
+    }
+
+    if (vflags != Qt::AlignTop && vflags != Qt::AlignVCenter && vflags != Qt::AlignBottom) {
+        vflags = defaultFlags & Qt::AlignVertical_Mask;
+    }
+
+    return hflags | vflags;
+}
+
 WaveformMarkProperties::WaveformMarkProperties(const QDomNode& node,
                                                const SkinContext& context,
                                                const WaveformSignalColors& signalColors) {
@@ -24,11 +61,7 @@ WaveformMarkProperties::WaveformMarkProperties(const QDomNode& node,
     }
 
     QString markAlign = context.selectString(node, "Align");
-    if (markAlign.contains("bottom", Qt::CaseInsensitive)) {
-        m_align = Qt::AlignBottom;
-    } else {
-        m_align = Qt::AlignTop; // Default
-    }
+    m_align = decodeAlignmentFlags(markAlign, Qt::AlignBottom | Qt::AlignHCenter);
 
     m_text = context.selectString(node, "Text");
     m_pixmapPath = context.selectString(node, "Pixmap");

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -80,7 +80,7 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
 }
 
 void WaveformMarkSet::clear() {
-    m_defaultMark = WaveformMark();
+    m_defaultMark.reset();
     m_marks.clear();
 }
 

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -64,6 +64,8 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     beatPen.setWidthF(1);
     painter->setPen(beatPen);
 
+    const Qt::Orientation orientation = m_waveformRenderer->getOrientation();
+    const float rendererWidth = m_waveformRenderer->getWidth();
     const float rendererHeight = m_waveformRenderer->getHeight();
 
     int beatCount = 0;
@@ -79,7 +81,11 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
             m_beats.resize(m_beats.size() * 2);
         }
 
-        m_beats[beatCount++].setLine(xBeatPoint, 0.0f, xBeatPoint, rendererHeight);
+        if (orientation == Qt::Horizontal) {
+            m_beats[beatCount++].setLine(xBeatPoint, 0.0f, xBeatPoint, rendererHeight);
+        } else {
+            m_beats[beatCount++].setLine(0.0f, xBeatPoint, rendererWidth, xBeatPoint);
+        }
     }
 
     // Make sure to use constData to prevent detaches!

--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -58,22 +58,11 @@ void WaveformRendererEndOfTrack::setup(const QDomNode& node, const SkinContext& 
         m_color = WSkinColor::getCorrectColor(m_color);
     }
     m_pen = QPen(QBrush(m_color), 2.5);
+    generateBackRects();
 }
 
 void WaveformRendererEndOfTrack::onResize() {
-    m_backRects.resize(4);
-    for (int i = 0; i < 4; i++) {
-        m_backRects[i].setTop(0);
-        m_backRects[i].setBottom(m_waveformRenderer->getHeight());
-        m_backRects[i].setLeft(m_waveformRenderer->getWidth() / 2 +
-                i*m_waveformRenderer->getWidth()/8);
-        m_backRects[i].setRight(m_waveformRenderer->getWidth());
-    }
-    // This is significant slower
-    //m_gradient.setStart(m_waveformRenderer->getWidth() / 2, 0);
-    //m_gradient.setFinalStop(m_waveformRenderer->getWidth(), 0);
-    //m_gradient.setColorAt(0, Qt::transparent);
-    //m_gradient.setColorAt(1, m_color);
+    generateBackRects();
 }
 
 void WaveformRendererEndOfTrack::draw(QPainter* painter,
@@ -151,4 +140,28 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
     //        m_waveformRenderer->getWidth() - 2, m_waveformRenderer->getHeight() - 2,
     //        m_gradient);
     painter->restore();
+}
+
+void WaveformRendererEndOfTrack::generateBackRects() {
+    m_backRects.resize(4);
+    for (int i = 0; i < 4; i++) {
+        if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
+            m_backRects[i].setTop(m_waveformRenderer->getHeight() / 2 +
+                    i * m_waveformRenderer->getHeight() / 8);
+            m_backRects[i].setBottom(m_waveformRenderer->getHeight());
+            m_backRects[i].setLeft(0);
+            m_backRects[i].setRight(m_waveformRenderer->getWidth());
+        } else {
+            m_backRects[i].setTop(0);
+            m_backRects[i].setBottom(m_waveformRenderer->getHeight());
+            m_backRects[i].setLeft(m_waveformRenderer->getWidth() / 2 +
+                    i * m_waveformRenderer->getWidth() / 8);
+            m_backRects[i].setRight(m_waveformRenderer->getWidth());
+        }
+    }
+    // This is significant slower
+    //m_gradient.setStart(m_waveformRenderer->getWidth() / 2, 0);
+    //m_gradient.setFinalStop(m_waveformRenderer->getWidth(), 0);
+    //m_gradient.setColorAt(0, Qt::transparent);
+    //m_gradient.setColorAt(1, m_color);
 }

--- a/src/waveform/renderers/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/waveformrendererendoftrack.h
@@ -27,6 +27,8 @@ class WaveformRendererEndOfTrack : public WaveformRendererAbstract {
     virtual void draw(QPainter* painter, QPaintEvent* event);
 
   private:
+    void generateBackRects();
+
     ControlProxy* m_pEndOfTrackControl;
     bool m_endOfTrackEnabled;
     ControlProxy* m_pTrackSampleRate;

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -18,9 +18,9 @@ WaveformRendererFilteredSignal::~WaveformRendererFilteredSignal() {
 }
 
 void WaveformRendererFilteredSignal::onResize() {
-    m_lowLines.resize(m_waveformRenderer->getWidth());
-    m_midLines.resize(m_waveformRenderer->getWidth());
-    m_highLines.resize(m_waveformRenderer->getWidth());
+    m_lowLines.resize(m_waveformRenderer->getLength());
+    m_midLines.resize(m_waveformRenderer->getLength());
+    m_highLines.resize(m_waveformRenderer->getLength());
 }
 
 void WaveformRendererFilteredSignal::onSetup(const QDomNode& node) {
@@ -56,34 +56,40 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
     painter->setWorldMatrixEnabled(false);
     painter->resetTransform();
 
+    // Rotate if drawing vertical waveforms
+    if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
+        painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
+    }
+
     const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
     const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
 
     // Represents the # of waveform data points per horizontal pixel.
     const double gain = (lastVisualIndex - firstVisualIndex) /
-            (double)m_waveformRenderer->getWidth();
+            (double)m_waveformRenderer->getLength();
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
     getGains(&allGain, &lowGain, &midGain, &highGain);
 
-    const float halfHeight = (float)m_waveformRenderer->getHeight()/2.0;
+    const float breadth = m_waveformRenderer->getBreadth();
+    const float halfBreadth = breadth / 2.0;
 
     const float heightFactor = m_alignment == Qt::AlignCenter
-            ? allGain*halfHeight/255.0
-            : allGain*m_waveformRenderer->getHeight()/255.0;
+            ? allGain*halfBreadth/255.0
+            : allGain*m_waveformRenderer->getBreadth()/255.0;
 
     //draw reference line
     if (m_alignment == Qt::AlignCenter) {
         painter->setPen(m_pColors->getAxesColor());
-        painter->drawLine(0,halfHeight,m_waveformRenderer->getWidth(),halfHeight);
+        painter->drawLine(0, halfBreadth, m_waveformRenderer->getLength(), halfBreadth);
     }
 
     int actualLowLineNumber = 0;
     int actualMidLineNumber = 0;
     int actualHighLineNumber = 0;
 
-    for (int x = 0; x < m_waveformRenderer->getWidth(); ++x) {
+    for (int x = 0; x < m_waveformRenderer->getLength(); ++x) {
         // Width of the x position in visual indices.
         const double xSampleWidth = gain * x;
 
@@ -120,7 +126,7 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         int visualIndexStart = visualFrameStart * 2;
         int visualIndexStop = visualFrameStop * 2;
 
-        // if (x == m_waveformRenderer->getWidth() / 2) {
+        // if (x == m_waveformRenderer->getLength() / 2) {
         //     qDebug() << "audioVisualRatio" << waveform->getAudioVisualRatio();
         //     qDebug() << "visualSampleRate" << waveform->getVisualSampleRate();
         //     qDebug() << "audioSamplesPerVisualPixel" << waveform->getAudioSamplesPerVisualSample();
@@ -150,19 +156,21 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         if (maxLow[0] && maxLow[1]) {
             switch (m_alignment) {
                 case Qt::AlignBottom :
+                case Qt::AlignRight :
                     m_lowLines[actualLowLineNumber].setLine(
-                        x, m_waveformRenderer->getHeight(),
-                        x, m_waveformRenderer->getHeight() - (int)(heightFactor*lowGain*(float)math_max(maxLow[0],maxLow[1])));
+                        x, breadth,
+                        x, breadth - (int)(heightFactor*lowGain*(float)math_max(maxLow[0],maxLow[1])));
                     break;
                 case Qt::AlignTop :
+                case Qt::AlignLeft :
                     m_lowLines[actualLowLineNumber].setLine(
                         x, 0,
                         x, (int)(heightFactor*lowGain*(float)math_max(maxLow[0],maxLow[1])));
                     break;
                 default :
                     m_lowLines[actualLowLineNumber].setLine(
-                        x, (int)(halfHeight-heightFactor*(float)maxLow[0]*lowGain),
-                        x, (int)(halfHeight+heightFactor*(float)maxLow[1]*lowGain));
+                        x, (int)(halfBreadth-heightFactor*(float)maxLow[0]*lowGain),
+                        x, (int)(halfBreadth+heightFactor*(float)maxLow[1]*lowGain));
                     break;
             }
             actualLowLineNumber++;
@@ -170,19 +178,21 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         if (maxMid[0] && maxMid[1]) {
             switch (m_alignment) {
                 case Qt::AlignBottom :
+                case Qt::AlignRight :
                     m_midLines[actualMidLineNumber].setLine(
-                        x, m_waveformRenderer->getHeight(),
-                        x, m_waveformRenderer->getHeight() - (int)(heightFactor*midGain*(float)math_max(maxMid[0],maxMid[1])));
+                        x, breadth,
+                        x, breadth - (int)(heightFactor*midGain*(float)math_max(maxMid[0],maxMid[1])));
                     break;
                 case Qt::AlignTop :
+                case Qt::AlignLeft :
                     m_midLines[actualMidLineNumber].setLine(
                         x, 0,
                         x, (int)(heightFactor*midGain*(float)math_max(maxMid[0],maxMid[1])));
                     break;
                 default :
                     m_midLines[actualMidLineNumber].setLine(
-                        x, (int)(halfHeight-heightFactor*(float)maxMid[0]*midGain),
-                        x, (int)(halfHeight+heightFactor*(float)maxMid[1]*midGain));
+                        x, (int)(halfBreadth-heightFactor*(float)maxMid[0]*midGain),
+                        x, (int)(halfBreadth+heightFactor*(float)maxMid[1]*midGain));
                     break;
             }
             actualMidLineNumber++;
@@ -190,19 +200,21 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         if (maxHigh[0] && maxHigh[1]) {
             switch (m_alignment) {
                 case Qt::AlignBottom :
+                case Qt::AlignRight :
                     m_highLines[actualHighLineNumber].setLine(
-                        x, m_waveformRenderer->getHeight(),
-                        x, m_waveformRenderer->getHeight() - (int)(heightFactor*highGain*(float)math_max(maxHigh[0],maxHigh[1])));
+                        x, breadth,
+                        x, breadth - (int)(heightFactor*highGain*(float)math_max(maxHigh[0],maxHigh[1])));
                     break;
                 case Qt::AlignTop :
+                case Qt::AlignLeft :
                     m_highLines[actualHighLineNumber].setLine(
                         x, 0,
                         x, (int)(heightFactor*highGain*(float)math_max(maxHigh[0],maxHigh[1])));
                     break;
                 default :
                     m_highLines[actualHighLineNumber].setLine(
-                        x, (int)(halfHeight-heightFactor*(float)maxHigh[0]*highGain),
-                        x, (int)(halfHeight+heightFactor*(float)maxHigh[1]*highGain));
+                        x, (int)(halfBreadth-heightFactor*(float)maxHigh[0]*highGain),
+                        x, (int)(halfBreadth+heightFactor*(float)maxHigh[1]*highGain));
                     break;
             }
             actualHighLineNumber++;

--- a/src/waveform/renderers/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/waveformrendererpreroll.cpp
@@ -28,8 +28,9 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
     if (!track) {
         return;
     }
+
     double samplesPerPixel = m_waveformRenderer->getVisualSamplePerPixel();
-    double numberOfSamples = m_waveformRenderer->getWidth() * samplesPerPixel;
+    double numberOfSamples = m_waveformRenderer->getLength() * samplesPerPixel;
 
     int currentPosition = m_waveformRenderer->getPlayPosVSample();
     //qDebug() << "currentPosition" << currentPosition
@@ -40,9 +41,9 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
     // where the pre-roll is located.
     if (currentPosition < numberOfSamples / 2.0) {
         int index = static_cast<int>(numberOfSamples / 2.0 - currentPosition);
-        const int polyWidth = static_cast<int>(40.0 / samplesPerPixel);
-        const float halfHeight = m_waveformRenderer->getHeight()/2.0;
-        const float halfPolyHeight = m_waveformRenderer->getHeight()/5.0;
+        const int polyLength = static_cast<int>(40.0 / samplesPerPixel);
+        const float halfBreadth = m_waveformRenderer->getBreadth()/2.0;
+        const float halfPolyBreadth = m_waveformRenderer->getBreadth()/5.0;
 
         painter->save();
         painter->setRenderHint(QPainter::Antialiasing);
@@ -50,24 +51,31 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
         //painter->setBackgroundMode(Qt::TransparentMode);
         painter->setWorldMatrixEnabled(false);
         painter->setPen(QPen(QBrush(m_color), 1));
+
+        // Rotate if drawing vertical waveforms
+        if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
+            painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
+        }
+
         QPolygonF polygon;
-        polygon << QPointF(0, halfHeight)
-                << QPointF(-polyWidth, halfHeight - halfPolyHeight)
-                << QPointF(-polyWidth, halfHeight + halfPolyHeight);
+        polygon << QPointF(0, halfBreadth)
+                << QPointF(-polyLength, halfBreadth - halfPolyBreadth)
+                << QPointF(-polyLength, halfBreadth + halfPolyBreadth);
 
         // Draw at most one not or halve visible polygon at the widget borders
-        if (index > (numberOfSamples + ((polyWidth + 1) * samplesPerPixel))) {
+        if (index > (numberOfSamples + ((polyLength + 1) * samplesPerPixel))) {
             int rest = index - numberOfSamples;
-            rest %= (int)((polyWidth + 1) * samplesPerPixel);
+            rest %= (int)((polyLength + 1) * samplesPerPixel);
             index = numberOfSamples + rest;
         }
 
         polygon.translate(((qreal)index) / samplesPerPixel, 0);
         while (index > 0) {
             painter->drawPolygon(polygon);
-            polygon.translate(-(polyWidth + 1), 0);
-            index -= (polyWidth + 1) * samplesPerPixel;
+            polygon.translate(-(polyLength + 1), 0);
+            index -= (polyLength + 1) * samplesPerPixel;
         }
+
         painter->restore();
     }
 }

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -20,6 +20,7 @@ WaveformRendererSignalBase::WaveformRendererSignalBase(
       m_pMidKillControlObject(NULL),
       m_pHighKillControlObject(NULL),
       m_alignment(Qt::AlignCenter),
+      m_orientation(Qt::Horizontal),
       m_pColors(NULL),
       m_axesColor_r(0),
       m_axesColor_g(0),
@@ -93,13 +94,30 @@ bool WaveformRendererSignalBase::init() {
 
 void WaveformRendererSignalBase::setup(const QDomNode& node,
                                        const SkinContext& context) {
-    QString alignString = context.selectString(node, "Align").toLower();
-    if (alignString == "bottom") {
-        m_alignment = Qt::AlignBottom;
-    } else if (alignString == "top") {
-        m_alignment = Qt::AlignTop;
+    QString orientationString = context.selectString(node, "Orientation").toLower();
+    if (orientationString == "vertical") {
+        m_orientation = Qt::Vertical;
     } else {
-        m_alignment = Qt::AlignCenter;
+        m_orientation = Qt::Horizontal;
+    }
+
+    QString alignString = context.selectString(node, "Align").toLower();
+    if (m_orientation == Qt::Horizontal) {
+        if (alignString == "bottom") {
+            m_alignment = Qt::AlignBottom;
+        } else if (alignString == "top") {
+            m_alignment = Qt::AlignTop;
+        } else {
+            m_alignment = Qt::AlignCenter;
+        }
+    } else {
+        if (alignString == "left") {
+            m_alignment = Qt::AlignLeft;
+        } else if (alignString == "right") {
+            m_alignment = Qt::AlignRight;
+        } else {
+            m_alignment = Qt::AlignCenter;
+        }
     }
 
     m_pColors = m_waveformRenderer->getWaveformSignalColors();

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -35,6 +35,7 @@ public:
     ControlProxy* m_pHighKillControlObject;
 
     Qt::Alignment m_alignment;
+    Qt::Orientation m_orientation;
 
     const WaveformSignalColors* m_pColors;
     qreal m_axesColor_r, m_axesColor_g, m_axesColor_b, m_axesColor_a;

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -54,17 +54,33 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
         if (samplePosition > 0.0) {
             double currentMarkPoint = m_waveformRenderer->transformSampleIndexInRendererWorld(samplePosition);
 
-            // NOTE: vRince I guess image width is odd to display the center on the exact line !
-            //external image should respect that ...
-            const int markHalfWidth = mark->m_image.width() / 2.0;
+            if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+                // NOTE: vRince I guess image width is odd to display the center on the exact line !
+                // external image should respect that ...
+                const int markHalfWidth = mark->m_image.width() / 2.0;
 
-            //check if the current point need to be displayed
-            if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
-                painter->drawImage(QPoint(currentMarkPoint-markHalfWidth,0), mark->m_image);
+                // Check if the current point need to be displayed
+                if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
+                    painter->drawImage(QPoint(currentMarkPoint - markHalfWidth,0), mark->m_image);
+                }
+            } else {
+                const int markHalfHeight = mark->m_image.height() / 2.0;
+
+                if (currentMarkPoint > -markHalfHeight && currentMarkPoint < m_waveformRenderer->getHeight() + markHalfHeight) {
+                    painter->drawImage(QPoint(0,currentMarkPoint - markHalfHeight), mark->m_image);
+                }
             }
         }
     }
+
     painter->restore();
+}
+
+void WaveformRenderMark::onResize() {
+    // Delete all marks' images. New images will be created on next paint.
+    for (int i = 0; i < m_marks.size(); i++) {
+        m_marks[i]->m_image = QImage();
+    }
 }
 
 void WaveformRenderMark::onSetTrack() {
@@ -126,9 +142,6 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 
     QPainter painter;
 
-    int labelRectWidth = 0;
-    int labelRectHeight = 0;
-
     // If no text is provided, leave m_markImage as a null image
     if (!markProperties.m_text.isNull()) {
         // Determine mark text.
@@ -158,21 +171,42 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         const int marginY = 1;
         wordRect.moveTop(marginX + 1);
         wordRect.moveLeft(marginY + 1);
+        wordRect.setHeight(wordRect.height() + (wordRect.height()%2));
         wordRect.setWidth(wordRect.width() + (wordRect.width())%2);
         //even wordrect to have an even Image >> draw the line in the middle !
 
-        labelRectWidth = wordRect.width() + 2*marginX + 4;
-        labelRectHeight = wordRect.height() + 2*marginY + 4 ;
+        int labelRectWidth = wordRect.width() + 2 * marginX + 4;
+        int labelRectHeight = wordRect.height() + 2 * marginY + 4 ;
 
         QRectF labelRect(0, 0,
                 (float)labelRectWidth, (float)labelRectHeight);
 
-        pMark->m_image = QImage(labelRectWidth+1,
-                m_waveformRenderer->getHeight(),
-                QImage::Format_ARGB32_Premultiplied);
+        int width;
+        int height;
 
-        if (markProperties.m_align == Qt::AlignBottom) {
-            labelRect.moveBottom(pMark->m_image.height()-1);
+        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+            width = 2 * labelRectWidth + 1;
+            height = m_waveformRenderer->getHeight();
+        } else {
+            width = m_waveformRenderer->getWidth();
+            height = 2 * labelRectHeight + 1;
+        }
+
+        pMark->m_image = QImage(width, height, QImage::Format_ARGB32_Premultiplied);
+
+        Qt::Alignment markAlignH = markProperties.m_align & Qt::AlignHorizontal_Mask;
+        Qt::Alignment markAlignV = markProperties.m_align & Qt::AlignVertical_Mask;
+
+        if (markAlignH == Qt::AlignHCenter) {
+            labelRect.moveLeft((width - labelRectWidth) / 2);
+        } else if (markAlignH == Qt::AlignRight) {
+            labelRect.moveRight(width - 1);
+        }
+
+        if (markAlignV == Qt::AlignVCenter) {
+            labelRect.moveTop((height - labelRectHeight) / 2);
+        } else if (markAlignV == Qt::AlignBottom) {
+            labelRect.moveBottom(height - 1);
         }
 
         // Fill with transparent pixels
@@ -183,55 +217,111 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 
         painter.setWorldMatrixEnabled(false);
 
-        //draw the label rect
+        // Prepare colors for drawing of marker lines
+        QColor lineColor = markProperties.m_color;
+        lineColor.setAlpha(200);
+        QColor contrastLineColor(0,0,0,120);
+
+        // Draw marker lines
+        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+            int middle = width / 2;
+            if (markAlignH == Qt::AlignHCenter) {
+                if (labelRect.top() > 0) {
+                    painter.setPen(lineColor);
+                    painter.drawLine(middle, 0, middle, labelRect.top());
+
+                    painter.setPen(contrastLineColor);
+                    painter.drawLine(middle - 1, 0, middle - 1, labelRect.top());
+                    painter.drawLine(middle + 1, 0, middle + 1, labelRect.top());
+                }
+
+                if (labelRect.bottom() < height) {
+                    painter.setPen(lineColor);
+                    painter.drawLine(middle, labelRect.bottom(), middle, height);
+
+                    painter.setPen(contrastLineColor);
+                    painter.drawLine(middle - 1, labelRect.bottom(), middle - 1, height);
+                    painter.drawLine(middle + 1, labelRect.bottom(), middle + 1, height);
+                }
+            } else {  // AlignLeft || AlignRight
+                painter.setPen(lineColor);
+                painter.drawLine(middle, 0, middle, height);
+
+                painter.setPen(contrastLineColor);
+                painter.drawLine(middle - 1, 0, middle - 1, height);
+                painter.drawLine(middle + 1, 0, middle + 1, height);
+            }
+        } else {  // Vertical
+            int middle = height / 2;
+            if (markAlignV == Qt::AlignVCenter) {
+                if (labelRect.left() > 0) {
+                    painter.setPen(lineColor);
+                    painter.drawLine(0, middle, labelRect.left(), middle);
+
+                    painter.setPen(contrastLineColor);
+                    painter.drawLine(0, middle - 1, labelRect.left(), middle - 1);
+                    painter.drawLine(0, middle + 1, labelRect.left(), middle + 1);
+                }
+
+                if (labelRect.right() < width) {
+                    painter.setPen(lineColor);
+                    painter.drawLine(labelRect.right(), middle, width, middle);
+
+                    painter.setPen(contrastLineColor);
+                    painter.drawLine(labelRect.right(), middle - 1, width, middle - 1);
+                    painter.drawLine(labelRect.right(), middle + 1, width, middle + 1);
+                }
+            } else {  // AlignTop || AlignBottom
+                painter.setPen(lineColor);
+                painter.drawLine(0, middle, width, middle);
+
+                painter.setPen(contrastLineColor);
+                painter.drawLine(0, middle - 1, width, middle - 1);
+                painter.drawLine(0, middle + 1, width, middle + 1);
+            }
+        }
+
+        // Draw the label rect
         QColor rectColor = markProperties.m_color;
-        rectColor.setAlpha(150);
+        rectColor.setAlpha(200);
         painter.setPen(markProperties.m_color);
         painter.setBrush(QBrush(rectColor));
         painter.drawRoundedRect(labelRect, 2.0, 2.0);
-        //painter.drawRect(labelRect);
 
-        //draw text
+        // Draw text
         painter.setBrush(QBrush(QColor(0,0,0,0)));
         painter.setFont(font);
         painter.setPen(markProperties.m_textColor);
         painter.drawText(labelRect, Qt::AlignCenter, label);
-
-        //draw line
-        QColor lineColor = markProperties.m_color;
-        lineColor.setAlpha(200);
-        painter.setPen(lineColor);
-
-        float middle = pMark->m_image.width() / 2.0;
-        //Default line align top
-        float lineTop = labelRectHeight + 1;
-        float lineBottom = pMark->m_image.height();
-
-        if (markProperties.m_align == Qt::AlignBottom) {
-            lineTop = 0.0;
-            lineBottom = pMark->m_image.height() - labelRectHeight - 1;
-        }
-
-        painter.drawLine(middle, lineTop, middle, lineBottom);
-
-        //other lines to increase contrast
-        painter.setPen(QColor(0,0,0,120));
-        painter.drawLine(middle - 1, lineTop, middle - 1, lineBottom);
-        painter.drawLine(middle + 1, lineTop, middle + 1, lineBottom);
-
     }
     else //no text draw triangle
     {
         float triangleSize = 9.0;
-        pMark->m_image = QImage(labelRectWidth+1,
-                m_waveformRenderer->getHeight(),
-                QImage::Format_ARGB32_Premultiplied);
+        float markLength = triangleSize + 1.0;
+        float markBreadth = m_waveformRenderer->getBreadth();
+
+        int width, height;
+
+        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+            width = markLength;
+            height = markBreadth;
+        } else {
+            width = markBreadth;
+            height = markLength;
+        }
+
+        pMark->m_image = QImage(width, height, QImage::Format_ARGB32_Premultiplied);
         pMark->m_image.fill(QColor(0,0,0,0).rgba());
 
         painter.begin(&pMark->m_image);
         painter.setRenderHint(QPainter::TextAntialiasing);
 
         painter.setWorldMatrixEnabled(false);
+
+        // Rotate if drawing vertical waveforms
+        if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
+            painter.setTransform(QTransform(0, 1, 1, 0, 0, 0));
+        }
 
         QColor triangleColor = markProperties.m_color;
         triangleColor.setAlpha(140);
@@ -249,9 +339,9 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         painter.drawPolygon(triangle);
 
         triangle.clear();
-        triangle.append(QPointF(0.0,pMark->m_image.height()));
-        triangle.append(QPointF(triangleSize+0.5,pMark->m_image.height()));
-        triangle.append(QPointF(triangleSize*0.5 + 0.1, pMark->m_image.height() - triangleSize*0.5 - 2.1));
+        triangle.append(QPointF(0.0,markBreadth));
+        triangle.append(QPointF(triangleSize+0.5,markBreadth));
+        triangle.append(QPointF(triangleSize*0.5 + 0.1, markBreadth - triangleSize*0.5 - 2.1));
 
         painter.drawPolygon(triangle);
 
@@ -260,10 +350,11 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         QColor lineColor = markProperties.m_color;
         lineColor.setAlpha(140);
         painter.setPen(lineColor);
-        float middle = pMark->m_image.width() / 2.0;
+
+        float middle = markLength / 2.0;
 
         float lineTop = triangleSize * 0.5 + 1;
-        float lineBottom = pMark->m_image.height() - triangleSize * 0.5 - 1;
+        float lineBottom = markBreadth - triangleSize * 0.5 - 1;
 
         painter.drawLine(middle, lineTop, middle, lineBottom);
 

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -18,6 +18,8 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
     virtual void setup(const QDomNode& node, const SkinContext& context);
     virtual void draw(QPainter* painter, QPaintEvent* event);
 
+    virtual void onResize() override;
+
     // Called when a new track is loaded.
     virtual void onSetTrack();
 

--- a/src/waveform/renderers/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/waveformrendermarkrange.cpp
@@ -62,7 +62,7 @@ void WaveformRenderMarkRange::draw(QPainter *painter, QPaintEvent * /*event*/) {
         double endPosition = m_waveformRenderer->transformSampleIndexInRendererWorld(endSample);
 
         //range not in the current display
-        if (startPosition > m_waveformRenderer->getWidth() || endPosition < 0)
+        if (startPosition > m_waveformRenderer->getLength() || endPosition < 0)
             continue;
 
         QImage* selectedImage = NULL;
@@ -71,7 +71,12 @@ void WaveformRenderMarkRange::draw(QPainter *painter, QPaintEvent * /*event*/) {
 
         // draw the corresponding portion of the selected image
         // this shouldn't involve *any* scaling it should be fast even in software mode
-        QRect rect(startPosition,0,endPosition-startPosition,m_waveformRenderer->getHeight());
+        QRect rect;
+        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+            rect.setRect(startPosition, 0, endPosition - startPosition, m_waveformRenderer->getHeight());
+        } else {
+            rect.setRect(0, startPosition, m_waveformRenderer->getWidth(), endPosition - startPosition);
+        }
         painter->drawImage(rect, *selectedImage, rect);
     }
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -138,9 +138,9 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
         // Track length in pixels.
         m_trackPixelCount = static_cast<double>(m_trackSamples) / 2.0 / m_audioSamplePerPixel;
 
-        // Ratio of half the width of the renderer to the track length in
+        // Ratio of half the length of the renderer to the track length in
         // pixels. Percent of the track shown in half the waveform widget.
-        double displayedLengthHalf = static_cast<double>(m_width) / m_trackPixelCount / 2.0;
+        double displayedLengthHalf = static_cast<double>(getLength()) / m_trackPixelCount / 2.0;
         // Avoid pixel jitter in play position by rounding to the nearest track
         // pixel.
         m_playPos = round(truePlayPos * m_trackPixelCount) / m_trackPixelCount; // Avoid pixel jitter in play position
@@ -188,11 +188,20 @@ void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
         }
 
         painter->setPen(m_colors.getPlayPosColor());
-        painter->drawLine(m_width/2,0,m_width/2,m_height);
+        if (m_orientation == Qt::Horizontal) {
+            painter->drawLine(m_width / 2, 0, m_width / 2, m_height);
+        } else {
+            painter->drawLine(0, m_height / 2, m_width, m_height / 2);
+        }
         painter->setOpacity(0.5);
         painter->setPen(m_colors.getBgColor());
-        painter->drawLine(m_width/2 + 1,0,m_width/2 + 1,m_height);
-        painter->drawLine(m_width/2 - 1,0,m_width/2 - 1,m_height);
+        if (m_orientation == Qt::Horizontal) {
+            painter->drawLine(m_width / 2 + 1, 0, m_width / 2 + 1, m_height);
+            painter->drawLine(m_width / 2 - 1, 0, m_width / 2 - 1, m_height);
+        } else {
+            painter->drawLine(0, m_height / 2 + 1, m_width, m_height / 2 + 1);
+            painter->drawLine(0, m_height / 2 - 1, m_width, m_height / 2 - 1);
+        }
     }
 
 #ifdef WAVEFORMWIDGETRENDERER_DEBUG
@@ -241,6 +250,13 @@ void WaveformWidgetRenderer::resize(int width, int height) {
 }
 
 void WaveformWidgetRenderer::setup(const QDomNode& node, const SkinContext& context) {
+    QString orientationString = context.selectString(node, "Orientation").toLower();
+    if (orientationString == "vertical") {
+        m_orientation = Qt::Vertical;
+    } else {
+        m_orientation = Qt::Horizontal;
+    }
+
     m_colors.setup(node, context);
     for (int i = 0; i < m_rendererStack.size(); ++i) {
         m_rendererStack[i]->setup(node, context);

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -73,6 +73,9 @@ class WaveformWidgetRenderer {
     void resize(int width, int height);
     int getHeight() const { return m_height;}
     int getWidth() const { return m_width;}
+    int getLength() const { return m_orientation == Qt::Horizontal ? m_width : m_height;}
+    int getBreadth() const { return m_orientation == Qt::Horizontal ? m_height : m_width;}
+    Qt::Orientation getOrientation() const { return m_orientation;}
     const WaveformSignalColors* getWaveformSignalColors() const { return &m_colors; };
 
     template< class T_Renderer>
@@ -88,6 +91,7 @@ class WaveformWidgetRenderer {
     const char* m_group;
     TrackPointer m_pTrack;
     QList<WaveformRendererAbstract*> m_rendererStack;
+    Qt::Orientation m_orientation;
     int m_height;
     int m_width;
     WaveformSignalColors m_colors;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -123,6 +123,13 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
         child = child.nextSibling();
     }
 
+    QString orientationString = context.selectString(node, "Orientation").toLower();
+    if (orientationString == "vertical") {
+        m_orientation = Qt::Vertical;
+    } else {
+        m_orientation = Qt::Horizontal;
+    }
+
     //qDebug() << "WOverview : m_marks" << m_marks.size();
     //qDebug() << "WOverview : m_markRanges" << m_markRanges.size();
     if (!m_connections.isEmpty()) {
@@ -249,7 +256,11 @@ void WOverview::onMarkRangeChange(double /*v*/) {
 }
 
 void WOverview::mouseMoveEvent(QMouseEvent* e) {
-    m_iPos = math_clamp(e->x(), 0, width() - 1);
+    if (m_orientation == Qt::Horizontal) {
+        m_iPos = math_clamp(e->x(), 0, width() - 1);
+    } else {
+        m_iPos = math_clamp(e->y(), 0, height() - 1);
+    }
     //qDebug() << "WOverview::mouseMoveEvent" << e->pos() << m_iPos;
     update();
 }
@@ -294,7 +305,11 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
 
         // Draw Axis
         painter.setPen(QPen(m_signalColors.getAxesColor(), 1));
-        painter.drawLine(0, height()/2, width(), height()/2);
+        if (m_orientation == Qt::Horizontal) {
+            painter.drawLine(0, height() / 2, width(), height() / 2);
+        } else {
+            painter.drawLine(width() / 2 , 0, width() / 2, height());
+        }
 
         // Draw waveform pixmap
         WaveformWidgetFactory* widgetFactory = WaveformWidgetFactory::instance();
@@ -311,8 +326,13 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
             if (m_diffGain != diffGain || m_waveformImageScaled.isNull()) {
                 QRect sourceRect(0, diffGain, m_pWaveformSourceImage->width(),
                     m_pWaveformSourceImage->height() - 2 * diffGain);
-                m_waveformImageScaled = m_pWaveformSourceImage->copy(
-                    sourceRect).scaled(size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+                QImage croppedImage = m_pWaveformSourceImage->copy(sourceRect);
+                if (m_orientation == Qt::Vertical) {
+                    // Rotate pixmap
+                    croppedImage = croppedImage.transformed(QTransform(0, 1, 1, 0, 0, 0));
+                }
+                m_waveformImageScaled = croppedImage.scaled(size(), Qt::IgnoreAspectRatio,
+                                                            Qt::SmoothTransformation);
                 m_diffGain = diffGain;
             }
 
@@ -322,8 +342,13 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
         if (m_dAnalyzerProgress < 1.0) {
             // Paint analyzer Progress
             painter.setPen(QPen(m_signalColors.getAxesColor(), 3));
-            painter.drawLine(m_dAnalyzerProgress * width(), height() / 2,
-                             width(), height() / 2);
+            if (m_orientation == Qt::Horizontal) {
+                painter.drawLine(m_dAnalyzerProgress * width(), height() / 2,
+                                 width(), height() / 2);
+            } else {
+                painter.drawLine(width() / 2 , m_dAnalyzerProgress * height(),
+                                 width() / 2, height());
+            }
         }
 
         if (m_dAnalyzerProgress <= 0.5) { // remove text after progress by wf is recognizable
@@ -343,7 +368,7 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
         if (m_trackLoaded && trackSamples > 0) {
             //qDebug() << "WOverview::paintEvent trackSamples > 0";
             const float offset = 1.0f;
-            const float gain = static_cast<float>(width()-2) / trackSamples;
+            const float gain = static_cast<float>(length() - 2) / trackSamples;
 
             // Draw range (loop)
             for (auto&& currentMarkRange : m_markRanges) {
@@ -375,8 +400,13 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                 }
 
                 // let top and bottom of the rect out of the widget
-                painter.drawRect(QRectF(QPointF(startPosition, -2.0),
-                                        QPointF(endPosition,height() + 1.0)));
+                if (m_orientation == Qt::Horizontal) {
+                    painter.drawRect(QRectF(QPointF(startPosition, -2.0),
+                                            QPointF(endPosition, height() + 1.0)));
+                } else {
+                    painter.drawRect(QRectF(QPointF(-2.0, startPosition),
+                                            QPointF(width() + 1.0, endPosition)));
+                }
             }
 
             // Draw markers (Cue & hotcues)
@@ -399,7 +429,12 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                     //        (currentMark.m_pointControl->get() / (float)m_trackSamplesControl->get()) * (float)(width()-2);
                     const float markPosition = offset + currentMark->m_pPointCos->get() * gain;
 
-                    const QLineF line(markPosition, 0.0, markPosition, static_cast<float>(height()));
+                    QLineF line;
+                    if (m_orientation == Qt::Horizontal) {
+                        line.setLine(markPosition, 0.0, markPosition, static_cast<float>(height()));
+                    } else {
+                        line.setLine(0.0, markPosition, static_cast<float>(width()), markPosition);
+                    }
                     painter.setPen(shadowPen);
                     painter.drawLine(line);
 
@@ -407,14 +442,43 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                     painter.drawLine(line);
 
                     if (!markProperties.m_text.isEmpty()) {
+                        Qt::Alignment halign = markProperties.m_align & Qt::AlignHorizontal_Mask;
+                        Qt::Alignment valign = markProperties.m_align & Qt::AlignVertical_Mask;
+                        QFontMetricsF metric(markerFont);
+                        QRectF textRect = metric.tightBoundingRect(markProperties.m_text);
                         QPointF textPoint;
-                        textPoint.setX(markPosition + 0.5f);
+                        if (m_orientation == Qt::Horizontal) {
+                            if (halign == Qt::AlignLeft) {
+                                textPoint.setX(markPosition - textRect.width());
+                            } else if (halign == Qt::AlignHCenter) {
+                                textPoint.setX(markPosition - textRect.width() / 2);
+                            } else {  // AlignRight
+                                textPoint.setX(markPosition + 0.5f);
+                            }
 
-                        if (markProperties.m_align == Qt::AlignTop) {
-                            QFontMetricsF metric(markerFont);
-                            textPoint.setY(metric.tightBoundingRect(markProperties.m_text).height()+0.5f);
-                        } else {
-                            textPoint.setY(float(height())-0.5f);
+                            if (valign == Qt::AlignTop) {
+                                textPoint.setY(textRect.height() + 0.5f);
+                            } else if (valign == Qt::AlignVCenter) {
+                                textPoint.setY((textRect.height() + height()) / 2);
+                            } else {  // AlignBottom
+                                textPoint.setY(float(height()) - 0.5f);
+                            }
+                        } else {  // Vertical
+                            if (halign == Qt::AlignLeft) {
+                                textPoint.setX(1.0f);
+                            } else if (halign == Qt::AlignHCenter) {
+                                textPoint.setX((width() - textRect.width()) / 2);
+                            } else {  // AlignRight
+                                textPoint.setX(width() - textRect.width());
+                            }
+
+                            if (valign == Qt::AlignTop) {
+                                textPoint.setY(markPosition - 1.0f);
+                            } else if (valign == Qt::AlignVCenter) {
+                                textPoint.setY(markPosition + textRect.height() / 2);
+                            } else {  // AlignBottom
+                                textPoint.setY(markPosition + metric.ascent());
+                            }
                         }
 
                         painter.setPen(shadowPen);
@@ -428,23 +492,27 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                 }
             }
 
+            if (m_orientation == Qt::Vertical) {
+                painter.setTransform(QTransform(0, 1, 1, 0, 0, 0));
+            }
+
             // draw current position
             painter.setPen(QPen(QBrush(m_qColorBackground),1));
             painter.setOpacity(0.5);
-            painter.drawLine(m_iPos + 1, 0, m_iPos + 1, height());
-            painter.drawLine(m_iPos - 1, 0, m_iPos - 1, height());
+            painter.drawLine(m_iPos + 1, 0, m_iPos + 1, breadth());
+            painter.drawLine(m_iPos - 1, 0, m_iPos - 1, breadth());
 
             painter.setPen(QPen(m_signalColors.getPlayPosColor(),1));
             painter.setOpacity(1.0);
-            painter.drawLine(m_iPos, 0, m_iPos, height());
+            painter.drawLine(m_iPos, 0, m_iPos, breadth());
 
             painter.drawLine(m_iPos - 2, 0, m_iPos, 2);
             painter.drawLine(m_iPos, 2, m_iPos + 2, 0);
             painter.drawLine(m_iPos - 2, 0, m_iPos + 2, 0);
 
-            painter.drawLine(m_iPos - 2, height() - 1, m_iPos, height() - 3);
-            painter.drawLine(m_iPos, height() - 3, m_iPos + 2, height() - 1);
-            painter.drawLine(m_iPos - 2, height() - 1, m_iPos + 2, height() - 1);
+            painter.drawLine(m_iPos - 2, breadth() - 1, m_iPos, breadth() - 3);
+            painter.drawLine(m_iPos, breadth() - 3, m_iPos + 2, breadth() - 1);
+            painter.drawLine(m_iPos - 2, breadth() - 1, m_iPos + 2, breadth() - 1);
         }
     }
     painter.end();
@@ -458,16 +526,20 @@ void WOverview::paintText(const QString &text, QPainter *painter) {
     QFont font = painter->font();
     QFontMetrics fm(font);
     int textWidth = fm.width(text);
-    if (textWidth > width()) {
+    if (textWidth > length()) {
         qreal pointSize = font.pointSizeF();
-        pointSize = pointSize * (width() - 5) / textWidth;
+        pointSize = pointSize * (length() - 5) / textWidth;
         if (pointSize < 6) {
             pointSize = 6;
         }
         font.setPointSizeF(pointSize);
         painter->setFont(font);
     }
+    if (m_orientation == Qt::Vertical) {
+        painter->setTransform(QTransform(0, 1, -1, 0, width(), 0));
+    }
     painter->drawText(10, 12, text);
+    painter->resetTransform();
 }
 
 void WOverview::resizeEvent(QResizeEvent * /*unused*/) {
@@ -482,7 +554,7 @@ void WOverview::resizeEvent(QResizeEvent * /*unused*/) {
 
     // These coeficients convert between widget space and normalized value
     // space.
-    m_a = (width() - 1) / (one - zero);
+    m_a = (length() - 1) / (one - zero);
     m_b = zero * m_a;
 
     m_waveformImageScaled = QImage();

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -55,6 +55,14 @@ class WOverview : public WWidget {
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
 
+    inline int length() {
+        return m_orientation == Qt::Horizontal ? width() : height();
+    }
+
+    inline int breadth() {
+        return m_orientation == Qt::Horizontal ? height() : width();
+    }
+
     ConstWaveformPointer getWaveform() const {
         return m_pWaveform;
     }
@@ -107,6 +115,8 @@ class WOverview : public WWidget {
     bool m_bDrag;
     // Internal storage of slider position in pixels
     int m_iPos;
+
+    Qt::Orientation m_orientation;
 
     QPixmap m_backgroundPixmap;
     QString m_backgroundPixmapPath;

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -43,7 +43,7 @@ bool WOverviewHSV::drawNextPixmapPart() {
     // Test if there is some new to draw (at least of pixel width)
     const int completionIncrement = waveformCompletion - m_actualCompletion;
 
-    int visiblePixelIncrement = completionIncrement * width() / dataSize;
+    int visiblePixelIncrement = completionIncrement * length() / dataSize;
     if (completionIncrement < 2 || visiblePixelIncrement == 0) {
         return false;
     }

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -45,7 +45,7 @@ bool WOverviewLMH::drawNextPixmapPart() {
     // Test if there is some new to draw (at least of pixel width)
     const int completionIncrement = waveformCompletion - m_actualCompletion;
 
-    int visiblePixelIncrement = completionIncrement * width() / dataSize;
+    int visiblePixelIncrement = completionIncrement * length() / dataSize;
     if (completionIncrement < 2 || visiblePixelIncrement == 0) {
         return false;
     }

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -42,7 +42,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
     // Test if there is some new to draw (at least of pixel width)
     const int completionIncrement = waveformCompletion - m_actualCompletion;
 
-    int visiblePixelIncrement = completionIncrement * width() / dataSize;
+    int visiblePixelIncrement = completionIncrement * length() / dataSize;
     if (completionIncrement < 2 || visiblePixelIncrement == 0) {
         return false;
     }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -57,9 +57,13 @@ void WWaveformViewer::resizeEvent(QResizeEvent* /*event*/) {
 }
 
 void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
+    if (!m_waveformWidget) {
+        return;
+    }
+
     m_mouseAnchor = event->pos();
 
-    if (event->button() == Qt::LeftButton && m_waveformWidget) {
+    if (event->button() == Qt::LeftButton) {
         // If we are pitch-bending then disable and reset because the two
         // shouldn't be used at once.
         if (m_bBending) {
@@ -67,8 +71,10 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
             m_bBending = false;
         }
         m_bScratching = true;
+        int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
+                    event->pos().x() : event->pos().y();
         double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
-        double targetPosition = -1.0 * event->pos().x() * audioSamplePerPixel * 2;
+        double targetPosition = -1.0 * eventPosValue * audioSamplePerPixel * 2;
         m_pScratchPosition->set(targetPosition);
         m_pScratchPositionEnable->slotSet(1.0);
     } else if (event->button() == Qt::RightButton) {
@@ -87,15 +93,23 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
 }
 
 void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
+    if (!m_waveformWidget) {
+        return;
+    }
+
     // Only send signals for mouse moving if the left button is pressed
-    if (m_bScratching && m_waveformWidget) {
+    if (m_bScratching) {
+        int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
+                    event->pos().x() : event->pos().y();
         // Adjusts for one-to-one movement.
         double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
-        double targetPosition = -1.0 * event->pos().x() * audioSamplePerPixel * 2;
+        double targetPosition = -1.0 * eventPosValue * audioSamplePerPixel * 2;
         //qDebug() << "Target:" << targetPosition;
         m_pScratchPosition->set(targetPosition);
     } else if (m_bBending) {
         QPoint diff = event->pos() - m_mouseAnchor;
+        int diffValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
+                    diff.x() : diff.y();
         // Start at the middle of [0.0, 1.0], and emit values based on how far
         // the mouse has traveled horizontally. Note, for legacy (MIDI) reasons,
         // this is tuned to 127.
@@ -103,7 +117,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         // control since we manually connect it in LegacySkinParser regardless
         // of whether the skin specifies it. See ControlTTRotaryBehavior to see
         // where this value is handled.
-        double v = 0.5 + (diff.x() / 1270.0);
+        double v = 0.5 + (diffValue / 1270.0);
         // clamp to [0.0, 1.0]
         v = math_clamp(v, 0.0, 1.0);
         m_pWheel->setParameter(v);


### PR DESCRIPTION
This is a significant update to the mapping. 

**Bug fixes **
  Touch platter + wheel touch speeds up/slows down song when wheel not enabled 
  Corrected Tap button mapping
  Correct Tap button led behavior when shift lock is active

  Adjusted mapping of AutoLoop to be identical to Numark user manual, Serato and Virtual DJ, 
 (1, 2, 4, 8) instead of 2, 4, 8, 16 if not shifted and 0.125, 0.25, 0.5, 16 if shifted (I already had this part done in my mapping before this week's pull request)

**FX section Mapping changes**

  Added InstantFx feature: FX are added to InstantFx by holding Tap and FX button. InstantFx are enabled/disabled directly with the Strip. 

 - Tap + FX button: Enables / Disables InstantFx.

  -Strip = Parameter 1 of FXs, 
  -TAP + Strip = Super knob

  -Beat knob = parameter 2 of FXs, 
  -TAP + Beat knob = Mix ratio
 - PadModeButton + Beat knob = Sampler volumes
 - Shift + BeatKnob = Beat grid move

  Connected controls for FX enabled 
  Removed soft takeover for Super FX knob (accessed by strip)
  Removed Callback function for FX Loaded to prevent all parameters from being automatically linked to Super Knob
  Removed configuration option BeatKnobAsSamplerVolume